### PR TITLE
Add script to analyze completion logprobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Completions Dataset
+
+This repository contains a sample `completions.json` file with logprob
+information produced by the OpenAI API.  The `analyze.py` script can
+be used to inspect token probabilities.
+
+## Usage
+
+```
+python3 analyze.py completions.json
+```
+
+The script prints each token in the completion, its probability, and
+the top alternatives. It also computes the average log probability for
+the full completion.

--- a/analyze.py
+++ b/analyze.py
@@ -1,0 +1,42 @@
+import json
+import argparse
+import math
+
+
+def analyze(path: str) -> None:
+    with open(path, 'r') as f:
+        data = json.load(f)
+    choices = data.get('choices', [])
+    if not choices:
+        print('No choices found')
+        return
+
+    logprobs = choices[0].get('logprobs', {}).get('content', [])
+    if not logprobs:
+        print('No logprobs found')
+        return
+
+    total_logprob = 0.0
+    print('Token analysis:')
+    for idx, entry in enumerate(logprobs, 1):
+        token = entry['token']
+        lp = entry['logprob']
+        prob = math.exp(lp)
+        total_logprob += lp
+        top_tokens = [t['token'] for t in entry.get('top_logprobs', [])[:5]]
+        print(f"{idx:2d}: {token!r} prob={prob:.4f} top={top_tokens}")
+
+    avg_logprob = total_logprob / len(logprobs)
+    avg_prob = math.exp(avg_logprob)
+    print(f"\nAverage logprob: {avg_logprob:.4f} -> probability {avg_prob:.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Analyze token probabilities in a completion file')
+    parser.add_argument('file', help='Path to completions.json')
+    args = parser.parse_args()
+    analyze(args.file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `analyze.py` script to inspect token probabilities
- document how to use the script in `README.md`

## Testing
- `python3 analyze.py completions.json | head`

------
https://chatgpt.com/codex/tasks/task_e_6872aaf1c2bc832a9b6c1ae08feeb73b