### PR TITLE
Add parser for concatenated messages

### DIFF
--- a/parse_messages.py
+++ b/parse_messages.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+
+def parse_concatenated_json(filename):
+    text = Path(filename).read_text()
+    decoder = json.JSONDecoder()
+    idx = 0
+    objs = []
+    text_len = len(text)
+    while idx < text_len:
+        obj, end = decoder.raw_decode(text, idx)
+        objs.append(obj)
+        idx = end
+        while idx < text_len and text[idx].isspace():
+            idx += 1
+    return objs
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(f"Usage: {argv[0]} <messages.json> [output.json]")
+        return 1
+    input_path = argv[1]
+    output_path = argv[2] if len(argv) > 2 else None
+    objs = parse_concatenated_json(input_path)
+    if output_path:
+        Path(output_path).write_text(json.dumps(objs, indent=2))
+    else:
+        json.dump(objs, sys.stdout, indent=2)
+        print()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- add `parse_messages.py` to decode back-to-back JSON objects

## Testing
- `python3 parse_messages.py messages.json > /dev/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_6884b7059314832a9152baca9d2478d0