### PR TITLE
Add utility to export logs as CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# completions
+
+This repository contains logs from the OpenAI API and some helper scripts.
+
+## Scripts
+
+- `parse_messages.py`: parse concatenated JSON logs into individual objects.
+- `json_to_csv.py`: convert a log file (e.g. `messages.json` or `completions.json`) to a CSV file with columns `id`, `role`, and `content`.
+
+## Usage
+
+To convert a log file to CSV:
+
+```bash
+python3 json_to_csv.py messages.json messages.csv
+```
+
+The CSV can then be loaded into a spreadsheet or analysis tool.

--- a/json_to_csv.py
+++ b/json_to_csv.py
@@ -1,0 +1,42 @@
+import json
+import csv
+import sys
+from pathlib import Path
+from typing import Iterable, Dict, Any
+
+from parse_messages import parse_concatenated_json
+
+
+def iter_messages(obj: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    """Yield message dictionaries from a parsed log object."""
+    for msg in obj.get("data", []):
+        yield msg
+
+
+def main(argv: Iterable[str]) -> int:
+    if len(argv) < 3:
+        print(f"Usage: {argv[0]} <input.json> <output.csv>")
+        return 1
+    input_path = Path(argv[1])
+    output_path = Path(argv[2])
+
+    objs = parse_concatenated_json(str(input_path))
+    rows = []
+    for obj in objs:
+        for msg in iter_messages(obj):
+            rows.append({
+                "id": msg.get("id"),
+                "role": msg.get("role"),
+                "content": msg.get("content"),
+            })
+
+    with output_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "role", "content"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/messages.csv
+++ b/messages.csv
@@ -1,0 +1,10 @@
+id,role,content
+chatcmpl-Bwj6BnEuYzy19fMLONnynBf3Joqkt-0,user,"Hello! It looks like you sent a message that sounds like something I might say. 😊 How can I assist you today? If you have any questions or need help with something, feel free to ask!"
+chatcmpl-Bwj4AJrJgUe2uZ9ZlKzj5l1EnLWqe-0,user,"Hello! Thank you for your warm welcome. How can I assist you today? If you have any questions, need information, or want help with a task, just let me know!"
+chatcmpl-Bwj2rn7NCWQFnXkSxX34O3i8wUzlr-0,user,"Hello! Thanks for reaching out. I’m here to help you with any questions or tasks you have—whether it’s information, advice, writing, or something else. How can I assist you today?"
+chatcmpl-Bwit0UTLraC3QaisLX9Y6aZdU3z0C-0,user,Hello! How can I assist you today?
+chatcmpl-BwiqXAp9bKdk0vdPBcLzLgi7KLZAu-0,user,Hello! How can I assist you today?
+chatcmpl-BwDGpwlhh2kkJfqEWyOVE1JFTRPEj-0,user,
+chatcmpl-BwDDYqSIv1V9DUPafaap1W4hCMBB7-0,user,
+chatcmpl-BwD6keEZGj1TEQmhk137gQaCXcvTn-0,user,
+chatcmpl-BwCztShAKwQbO8W75m1Ifa5EMjM9o-0,user,Write a one-sentence bedtime story about a unicorn.


### PR DESCRIPTION
## Summary
- add `json_to_csv.py` to convert concatenated logs to CSV
- document scripts in `README`
- provide example CSV export from `messages.json`

## Testing
- `python3 json_to_csv.py messages.json messages.csv`
- `python3 -m py_compile json_to_csv.py parse_messages.py`


------
https://chatgpt.com/codex/tasks/task_e_6884b7ff3620832ab6a017c593d69b96