### PR TITLE
Convert prompt format

### DIFF
--- a/completions_old.json
+++ b/completions_old.json
@@ -17,7 +17,11 @@
       "completion_tokens": 6,
       "total_tokens": 11
     },
-    "prompt": "Say this is a test"
+    "prompt": {
+      "content": {
+        "text": "Say this is a test"
+      }
+    }
   },
   {
     "id": "cmpl-BxorMu1DyXZSlKYDqKUs7QxVprxP8",
@@ -196,7 +200,11 @@
       "completion_tokens": 6,
       "total_tokens": 11
     },
-    "prompt": "Say this is a test"
+    "prompt": {
+      "content": {
+        "text": "Say this is a test"
+      }
+    }
   },
   {
     "id": "cmpl-BxpaaFPKkEXIIWTyfPbG4Bxg2H4R3",
@@ -400,7 +408,11 @@
       "completion_tokens": 7,
       "total_tokens": 8
     },
-    "prompt": ""
+    "prompt": {
+      "content": {
+        "text": ""
+      }
+    }
   },
   {
     "id": "cmpl-Bxpc9AqOf2sIPVVJ9hStmVtyNXV9O",
@@ -442,8 +454,8 @@
             -0.0012248703,
             -0.0004515262,
             -0.0024090658,
-            -0.00005443128,
-            -8.537869e-6,
+            -5.443128e-05,
+            -8.537869e-06,
             -0.00025335286,
             -0.00018327577,
             -0.00018971277
@@ -692,7 +704,7 @@
               "...\n\n": -13.260872
             },
             {
-              " the": -0.00005443128,
+              " the": -5.443128e-05,
               " The": -10.449164,
               "\n\n": -11.553472,
               "the": -12.118228,
@@ -714,7 +726,7 @@
               "…": -16.296587
             },
             {
-              " Year": -8.537869e-6,
+              " Year": -8.537869e-06,
               " year": -12.745873,
               "\n\n": -13.202098,
               "Year": -14.264127,
@@ -829,7 +841,11 @@
       "completion_tokens": 16,
       "total_tokens": 17
     },
-    "prompt": ""
+    "prompt": {
+      "content": {
+        "text": ""
+      }
+    }
   },
   {
     "id": "cmpl-BxpfPLyjxHK4PL3uzRRE5YRyNq2ja",
@@ -1008,7 +1024,11 @@
       "completion_tokens": 6,
       "total_tokens": 11
     },
-    "prompt": "Say this is a test"
+    "prompt": {
+      "content": {
+        "text": "Say this is a test"
+      }
+    }
   },
   {
     "id": "cmpl-BxpkrOf5AT69xhFsol5r9XOEzcFGY",
@@ -1197,7 +1217,11 @@
       "completion_tokens": 16,
       "total_tokens": 17
     },
-    "prompt": ""
+    "prompt": {
+      "content": {
+        "text": ""
+      }
+    }
   },
   {
     "id": "cmpl-Bxpu7Of6QgwcXeiZldWpz7fp1KGya",
@@ -1386,6 +1410,10 @@
       "completion_tokens": 16,
       "total_tokens": 17
     },
-    "prompt": ""
+    "prompt": {
+      "content": {
+        "text": ""
+      }
+    }
   }
 ]

--- a/fix_prompt_structure.py
+++ b/fix_prompt_structure.py
@@ -1,0 +1,27 @@
+import json
+import sys
+
+FILENAME = 'completions_old.json'
+
+with open(FILENAME, 'r', encoding='utf-8') as f:
+    data = json.load(f)
+
+changed = False
+for item in data:
+    if 'prompt' in item:
+        prompt_val = item['prompt']
+        # if it's already in desired format, skip
+        if isinstance(prompt_val, dict) and 'content' in prompt_val and isinstance(prompt_val['content'], dict) and 'text' in prompt_val['content']:
+            continue
+        if isinstance(prompt_val, dict) and 'text' in prompt_val:
+            text_val = prompt_val['text']
+        else:
+            text_val = prompt_val
+        item['prompt'] = { 'content': { 'text': text_val } }
+        changed = True
+
+if changed:
+    with open(FILENAME, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+print('Updated' if changed else 'No changes needed')


### PR DESCRIPTION
## Summary
- convert `prompt` objects in `completions_old.json` to nested structure `prompt.content.text`
- add helper script `fix_prompt_structure.py` that performs this transformation

## Testing
- `python3 fix_prompt_structure.py`

------
https://chatgpt.com/codex/tasks/task_e_6888c2a7c798832a86a7ec8c605ad8d8